### PR TITLE
Update dependency to symfony/console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Command to handle freistil Boxfiles anywhere",
     "require": {
         "symfony/yaml": "2.*",
-        "symfony/console": "2.*",
+        "symfony/console": "2.* || 3.*",
         "symfony/config": "~2.6",
         "derhasi/symlinker": ">=0.2.2"
     },


### PR DESCRIPTION
Allow using symfony/console 3.x, which is required by Drupal >=8.4.