### PR TITLE
Update symfony config/yaml dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "symfony/yaml": "2.* || 3.*",
         "symfony/console": "2.* || 3.*",
         "symfony/config": "~2.6 || 3.*",
-        "derhasi/symlinker": ">=0.2.2"
+        "derhasi/symlinker": ">0.4.0"
     },
     "type": "cli",
     "license": "GPL-2.0-or-later",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "symfony/yaml": "2.* || 3.*",
         "symfony/console": "2.* || 3.*",
-        "symfony/config": "~2.6 || ~3.2.0",
+        "symfony/config": "~2.6 || 3.*",
         "derhasi/symlinker": ">=0.2.2"
     },
     "type": "cli",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "symfony/yaml": "2.* || 3.*",
         "symfony/console": "2.* || 3.*",
         "symfony/config": "~2.6 || 3.*",
-        "derhasi/symlinker": ">0.4.0"
+        "derhasi/symlinker": ">=0.2.2"
     },
     "type": "cli",
     "license": "GPL-2.0-or-later",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "derhasi/boxfile",
     "description": "Command to handle freistil Boxfiles anywhere",
     "require": {
-        "symfony/yaml": "2.* || ~3.2.0",
+        "symfony/yaml": "2.* || 3.*",
         "symfony/console": "2.* || 3.*",
         "symfony/config": "~2.6 || ~3.2.0",
         "derhasi/symlinker": ">=0.2.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0330159d30d7e3ec6b76035d7a80b59",
+    "content-hash": "077f4b580b07557257afc2d0f761a553",
     "packages": [
         {
             "name": "derhasi/symlinker",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "98d520881c16039283d4fb6d48c79f6e",
-    "content-hash": "e9fea07857000d337536a2db825dbc7e",
+    "content-hash": "c0330159d30d7e3ec6b76035d7a80b59",
     "packages": [
         {
             "name": "derhasi/symlinker",
@@ -46,7 +45,7 @@
                 }
             ],
             "description": "A PHP library and CLI tool to create symlinks",
-            "time": "2015-11-20 16:38:49"
+            "time": "2015-11-20T16:38:49+00:00"
         },
         {
             "name": "symfony/config",
@@ -54,12 +53,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "6c905bbed1e728226de656e4c07d620dfe9e80d9"
+                "reference": "65791be28189e2c3d2d289d1b0b23d1f1e521c65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/6c905bbed1e728226de656e4c07d620dfe9e80d9",
-                "reference": "6c905bbed1e728226de656e4c07d620dfe9e80d9",
+                "url": "https://api.github.com/repos/symfony/config/zipball/65791be28189e2c3d2d289d1b0b23d1f1e521c65",
+                "reference": "65791be28189e2c3d2d289d1b0b23d1f1e521c65",
                 "shasum": ""
             },
             "require": {
@@ -96,7 +95,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-09 16:07:40"
+            "time": "2015-07-09T16:07:40+00:00"
         },
         {
             "name": "symfony/console",
@@ -153,7 +152,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-28 15:18:12"
+            "time": "2015-07-28T15:18:12+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -202,7 +201,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-09 16:07:40"
+            "time": "2015-07-09T16:07:40+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -251,7 +250,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-28 14:07:07"
+            "time": "2015-07-28T14:07:07+00:00"
         },
         {
             "name": "webmozart/path-util",
@@ -292,7 +291,7 @@
                 }
             ],
             "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
-            "time": "2015-03-19 10:57:25"
+            "time": "2015-03-19T10:57:25+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
Currently the required version for `symfony/yaml` is `~3.2.0` as well as `symfony/config` with version `~3.2.0`. Unfortunately this does not allow to use this package with Drupal 8.5.0, which requires `symfony/yam:~3.4.5` and a corresponding `~3.4` version of `symfony/config`.

So here is a pull request to bump these versions to `3.*` to have it compatible with Drupal <=8.5.0.

*NOTE:* This PR requires a corresponding update of [derhasi/symlinker](https://github.com/derhasi/symlinker) - see https://github.com/derhasi/symlinker/pull/5